### PR TITLE
Add search, multi-translation comparison, and verse of the day

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -203,6 +203,24 @@ get '/data/:translation/random/:book_id' do
   { translation: translation_as_json(translation), random_verse: verse }.to_json
 end
 
+get '/data/:translation/verse_of_day' do
+  content_type 'application/json', charset: 'utf-8'
+  headers CORS_HEADERS
+
+  translation = get_translation
+  total = DB['select count(*) as count from verses where translation_id = ?', translation[:id]].first[:count]
+  verse_index = (Date.today.yday * 1_000_003) % total
+  verse =
+    DB[
+      'select book_id, book, chapter, verse, text from verses where translation_id = ? order by id limit 1 offset ?',
+      translation[:id],
+      verse_index
+    ].first
+  halt 404, jsonp(error: 'no verse found') unless verse
+
+  { translation: translation_as_json(translation), verse: verse, date: Date.today.to_s }.to_json
+end
+
 get '/data/:translation/:book_id' do
   content_type 'application/json', charset: 'utf-8'
   headers CORS_HEADERS
@@ -243,6 +261,30 @@ get '/data/:translation/:book_id/:chapter' do
   { translation: translation_as_json(translation), verses: }.to_json
 end
 
+get '/search' do
+  content_type 'application/json', charset: 'utf-8'
+  headers CORS_HEADERS
+
+  query = params[:q].to_s.strip
+  halt 400, jsonp(error: 'query parameter q required (minimum 3 characters)') if query.length < 3
+
+  translation = get_translation
+  limit = params[:limit].to_i
+  limit = 20 unless (1..50).cover?(limit)
+  page = [params[:page].to_i, 1].max
+
+  verses =
+    DB[
+      'select book_id, book, chapter, verse, text from verses where translation_id = :translation_id and text like :pattern order by book_num, chapter, verse limit :limit offset :offset',
+      translation_id: translation[:id],
+      pattern: "%#{query}%",
+      limit: limit,
+      offset: (page - 1) * limit
+    ].to_a
+
+  { translation: translation_as_json(translation), query: query, verses: verses, page: page, limit: limit }.to_json
+end
+
 options '/:ref' do
   headers CORS_HEADERS
   200
@@ -252,7 +294,11 @@ get '/:ref' do
   content_type 'application/json', charset: 'utf-8'
   headers CORS_HEADERS
   ref_string = params[:ref].tr('+', ' ')
-  display_verse_from(ref_string)
+  if params[:translations]
+    compare_translations(ref_string)
+  else
+    display_verse_from(ref_string)
+  end
 end
 
 def display_verse_from(ref_string)
@@ -292,6 +338,24 @@ def display_verse_from(ref_string)
     response = { error: 'not found' }
   end
   jsonp response
+end
+
+def compare_translations(ref_string)
+  identifiers = params[:translations].split(',').map(&:strip).first(5)
+  halt 400, jsonp(error: 'specify at least one translation') if identifiers.empty?
+
+  results =
+    identifiers.filter_map do |identifier|
+      t = DB['select * from translations where identifier = ?', identifier].first
+      next unless t
+      ref = BibleRef::Reference.new(ref_string, language: t[:language_code], single_chapter_book_matching: single_chapter_book_matching)
+      next unless (ranges = ref.ranges)
+      verses = get_verses(ranges, t[:id])
+      next unless verses
+      render_response(verses: verses, ref: ref.normalize, translation: t)
+    end
+
+  jsonp(results: results)
 end
 
 def single_chapter_book_matching

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -510,4 +510,94 @@ RSpec.describe 'Bible API', type: :request do
       expect(last_response.content_type).to include('charset=utf-8')
     end
   end
+
+  describe 'GET /search' do
+    it 'returns verses matching the query' do
+      get '/search?q=love'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      expect_cors_headers
+
+      response = json_response
+      expect(response).to have_key('translation')
+      expect(response).to have_key('query')
+      expect(response).to have_key('verses')
+      expect(response).to have_key('page')
+      expect(response).to have_key('limit')
+      expect(response['query']).to eq('love')
+      expect(response['verses']).to be_an(Array)
+      expect(response['verses']).not_to be_empty
+      expect(response['verses'].first).to include('book_id', 'book', 'chapter', 'verse', 'text')
+    end
+
+    it 'respects translation parameter' do
+      get '/search?q=love&translation=kjv'
+      expect(last_response).to be_ok
+      expect(json_response['translation']['identifier']).to eq('kjv')
+    end
+
+    it 'defaults to 20 results per page' do
+      get '/search?q=the'
+      expect(last_response).to be_ok
+      response = json_response
+      expect(response['limit']).to eq(20)
+      expect(response['verses'].length).to be <= 20
+    end
+
+    it 'respects limit parameter' do
+      get '/search?q=love&limit=5'
+      expect(last_response).to be_ok
+      expect(json_response['verses'].length).to be <= 5
+    end
+
+    it 'returns 400 for queries shorter than 3 characters' do
+      get '/search?q=ab'
+      expect(last_response.status).to eq(400)
+    end
+
+    it 'returns 400 when q is missing' do
+      get '/search'
+      expect(last_response.status).to eq(400)
+    end
+
+    it 'paginates results' do
+      get '/search?q=love&limit=5&page=1'
+      page1 = json_response['verses']
+      get '/search?q=love&limit=5&page=2'
+      page2 = json_response['verses']
+      expect(page1).not_to eq(page2)
+    end
+  end
+
+  describe 'Multi-translation comparison' do
+    it 'returns multiple translations for a verse' do
+      get '/John+3:16?translations=web,kjv'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+
+      response = json_response
+      expect(response).to have_key('results')
+      expect(response['results'].length).to eq(2)
+      identifiers = response['results'].map { |r| r['translation_id'] }
+      expect(identifiers).to include('web', 'kjv')
+    end
+
+    it 'returns single result for one translation' do
+      get '/John+3:16?translations=kjv'
+      expect(last_response).to be_ok
+      expect(json_response['results'].length).to eq(1)
+    end
+
+    it 'skips unknown translations gracefully' do
+      get '/John+3:16?translations=web,unknown_xyz'
+      expect(last_response).to be_ok
+      expect(json_response['results'].length).to eq(1)
+    end
+
+    it 'caps results at 5 translations' do
+      get '/John+3:16?translations=web,kjv,asv,bbe,darby,dra'
+      expect(last_response).to be_ok
+      expect(json_response['results'].length).to be <= 5
+    end
+  end
 end

--- a/spec/requests/data_api_spec.rb
+++ b/spec/requests/data_api_spec.rb
@@ -718,4 +718,41 @@ RSpec.describe 'Data API Endpoints', type: :request do
       expect_cors_headers
     end
   end
+
+  describe 'GET /data/:translation/verse_of_day' do
+    it 'returns a verse with expected structure' do
+      get '/data/web/verse_of_day'
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to include('application/json')
+      expect_cors_headers
+
+      response = json_response
+      expect(response).to have_key('translation')
+      expect(response).to have_key('verse')
+      expect(response).to have_key('date')
+      expect(response['date']).to match(/\d{4}-\d{2}-\d{2}/)
+
+      verse = response['verse']
+      expect(verse).to include('book_id', 'book', 'chapter', 'verse', 'text')
+    end
+
+    it 'returns the same verse for the same day' do
+      get '/data/web/verse_of_day'
+      first = json_response['verse']
+      get '/data/web/verse_of_day'
+      second = json_response['verse']
+      expect(first).to eq(second)
+    end
+
+    it 'works with kjv translation' do
+      get '/data/kjv/verse_of_day'
+      expect(last_response).to be_ok
+      expect(json_response['translation']['identifier']).to eq('kjv')
+    end
+
+    it 'returns 404 for unknown translation' do
+      get '/data/unknown_xyz/verse_of_day'
+      expect(last_response.status).to eq(404)
+    end
+  end
 end

--- a/views/index.erb
+++ b/views/index.erb
@@ -137,6 +137,41 @@ provided by <a href="https://timmorgan.dev">Tim Morgan</a>.</p>
   </section>
 </div>
 
+<h2>Search API</h2>
+
+<p>Search for verses containing a word or phrase across any translation.</p>
+
+<pre><code><%= @host %>/search?q=QUERY[&translation=TRANSLATION][&page=PAGE][&limit=LIMIT]</code></pre>
+
+<dl>
+  <dt><code>q</code></dt>
+  <dd>The search term (minimum 3 characters). Case-insensitive.</dd>
+  <dt><code>translation</code></dt>
+  <dd>Translation identifier (default: WEB).</dd>
+  <dt><code>page</code></dt>
+  <dd>Page number for paginated results (default: 1).</dd>
+  <dt><code>limit</code></dt>
+  <dd>Results per page, between 1 and 50 (default: 20).</dd>
+</dl>
+
+<p>Example: <a href="/search?q=love&translation=kjv">/search?q=love&amp;translation=kjv</a></p>
+
+<h2>Multi-Translation Comparison</h2>
+
+<p>Get the same passage in multiple translations at once by adding a <code>translations</code> parameter (comma-separated, up to 5).</p>
+
+<pre><code><%= @host %>/BOOK+CHAPTER:VERSE?translations=TRANS1,TRANS2,...</code></pre>
+
+<p>Example: <a href="/john+3:16?translations=web,kjv">/john+3:16?translations=web,kjv</a></p>
+
+<h2>Verse of the Day</h2>
+
+<p>Returns a daily verse that changes each day of the year (same verse for all requests on the same day).</p>
+
+<pre><code><%= @host %>/data/TRANSLATION_ID/verse_of_day</code></pre>
+
+<p>Example: <a href="/data/web/verse_of_day">/data/web/verse_of_day</a></p>
+
 <h2>Translations</h2>
 
 <p>Both APIs support these translations:</p>


### PR DESCRIPTION
## Summary

Adds three new API features:

- **Full-text search** — `GET /search?q=QUERY&translation=kjv&page=1&limit=20`
  - Case-insensitive LIKE search across any translation
  - Paginated (1–50 results per page)
  - Minimum 3-character query enforced

- **Multi-translation comparison** — `GET /:ref?translations=web,kjv,asv`
  - Fetches the same passage in up to 5 translations at once
  - Returns array of results, skips unknown/invalid translations gracefully

- **Verse of the Day** — `GET /data/:translation/verse_of_day`
  - Date-seeded: returns the same verse for all requests on the same calendar day
  - Uses a prime-number scatter to vary verses throughout the year

## Also included

- Homepage documentation updated for all three endpoints
- RSpec tests added for all new endpoints

## Notes

Search uses `LIKE` so no schema migration needed. A `FULLTEXT` index on `verses.text` could be added later for better performance at scale.